### PR TITLE
Improve handling of graphics and figures

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,7 @@ A set of course notes are provided in either Markdown or LaTeX along with a conf
 
 ### Prerequisites
  * Ensure a system TeX distribution such as TeX Live or MacTeX is installed.
- * Install pdf2svg using your standard package manager (e.g. `apt install pdf2svg`)
- * Install libyaml using your standard package manager (e.g. `apt install libyaml-dev`)
+ * Install pdf2svg, pdf2ppm and libyaml using your standard package manager (e.g. on Ubuntu: `apt install pdf2svg poppler-utils libyaml-dev`)
  * Ensure the `virtualenv` python package is installed.
 
 ### Quick Installation

--- a/makeCourse/makecourse.sty
+++ b/makeCourse/makecourse.sty
@@ -17,6 +17,7 @@
 	\newcommand{\youtube}[2][Visit the URL below to view a video:]{\bigskip\noindent\textbf{Video} \textrm{#1}\\\expandafter\url{https://www.youtube.com/embed/#2}\par}
 		\newcommand{\embed}[1]{\url{#1}}
 		\newcommand{\recap}[2][Visit the URL below to view recap:]{\bigskip\noindent\textbf{Recap} \textrm{#1}\\\expandafter\url{https://campus.recap.ncl.ac.uk/Panopto/Pages/Viewer.aspx?id=#2}\par}
+		\newcommand{\alt}[1]{}
 \fi
 
 \endinput

--- a/makeCourse/plasTeXRenderer/Floats.jinja2s
+++ b/makeCourse/plasTeXRenderer/Floats.jinja2s
@@ -13,7 +13,7 @@ name: marginpar
 
 name: caption
 <figcaption>
-  <span class="caption_title"><b>{{ obj.title }}</b></span>
-  <span class="caption_ref"><b>{{ obj.ref }}</b></span>
+  <span class="caption_title">{{ obj.title }}</span>
+  <span class="caption_ref">{{ obj.ref }}</span>
   <span class="caption_text">{{ obj }}</span> 
 </figcaption>

--- a/makeCourse/plasTeXRenderer/caption/caption.jinja2s
+++ b/makeCourse/plasTeXRenderer/caption/caption.jinja2s
@@ -1,6 +1,6 @@
 name: caption
 <figcaption>
-  {% if obj.title %}<span class="caption_title"><b>{{ obj.title }}</b></span>{% endif %}
-  {% if obj.ref %}<span class="caption_ref"><b>{{ obj.ref }}</b></span>{% endif %}
-  <span class="caption_text">{{ obj }}</span> 
+  {% if obj.title %}<span class="caption_title">{{ obj.title }}</span>{% endif %}
+  {% if obj.ref %}<span class="caption_ref">{{ obj.ref }}</span>{% endif %}
+  <span class="caption_text">{{ obj }}</span>
 </figcaption>

--- a/makeCourse/plasTeXRenderer/graphicx.jinja2s
+++ b/makeCourse/plasTeXRenderer/graphicx.jinja2s
@@ -15,6 +15,10 @@ name: endvimeo
 " frameborder="0"></iframe>
 
 name: includegraphics rotatebox scalebox reflectbox resizebox
-<img src="{{ obj.image.url }}" style="{{ obj.style.inline }}">
+{% if obj.altText %}
+	<img alt="{{ obj.altText|e }}" src="{{ obj.image.url }}" style="{{ obj.style.inline }}">
+{% else %}
+	<img src="{{ obj.image.url }}" style="{{ obj.style.inline }}">
+{% endif %}
 
-name: DeclareGraphicsExtensions graphicspath
+name: DeclareGraphicsExtensions graphicspath alt

--- a/makeCourse/plasTeXRenderer/graphicx.jinja2s
+++ b/makeCourse/plasTeXRenderer/graphicx.jinja2s
@@ -16,7 +16,7 @@ name: endvimeo
 
 name: includegraphics rotatebox scalebox reflectbox resizebox
 {% if obj.altText %}
-	<img alt="{{ obj.altText|e }}" src="{{ obj.image.url }}" style="{{ obj.style.inline }}">
+	<img alt="{{ obj.altText.textContent|e }}" src="{{ obj.image.url }}" style="{{ obj.style.inline }}">
 {% else %}
 	<img src="{{ obj.image.url }}" style="{{ obj.style.inline }}">
 {% endif %}

--- a/makeCourse/plasTeXRenderer/tikzpicture.jinja2
+++ b/makeCourse/plasTeXRenderer/tikzpicture.jinja2
@@ -1,7 +1,15 @@
 <div class="tikzcd" id="{{ obj.id }}">
   {% if obj.renderer.vectorImager.enabled %}
-    <img src="{{ obj.vectorImage.url }}" alt="{{ obj.source|e }}" />
+	{% if obj.altText %}
+		<img src="{{ obj.vectorImage.url }}" alt="{{ obj.altText|e }}"/>
+	{% else %}
+		<img src="{{ obj.vectorImage.url }}" alt="{{ obj.source|e }}" />
+	{% endif %}
   {% else %}
-    <img src="{{ obj.image.url }}" alt="{{ obj.source|e }}" />
+	{% if obj.altText %}
+		<img src="{{ obj.image.url }}" alt="{{ obj.altText|e }}" />
+	{% else %}
+		<img src="{{ obj.image.url }}" alt="{{ obj.source|e }}" />
+	{% endif %}
   {% endif %}
 </div>

--- a/makeCourse/plasTeXRenderer/tikzpicture.jinja2
+++ b/makeCourse/plasTeXRenderer/tikzpicture.jinja2
@@ -1,13 +1,13 @@
 <div class="tikzcd" id="{{ obj.id }}">
   {% if obj.renderer.vectorImager.enabled %}
 	{% if obj.altText %}
-		<img src="{{ obj.vectorImage.url }}" alt="{{ obj.altText|e }}"/>
+		<img src="{{ obj.vectorImage.url }}" alt="{{ obj.altText.textContent|e }}"/>
 	{% else %}
 		<img src="{{ obj.vectorImage.url }}" alt="{{ obj.source|e }}" />
 	{% endif %}
   {% else %}
 	{% if obj.altText %}
-		<img src="{{ obj.image.url }}" alt="{{ obj.altText|e }}" />
+		<img src="{{ obj.image.url }}" alt="{{ obj.altText.textContent|e }}" />
 	{% else %}
 		<img src="{{ obj.image.url }}" alt="{{ obj.source|e }}" />
 	{% endif %}

--- a/makeCourse/plastex/__init__.py
+++ b/makeCourse/plastex/__init__.py
@@ -91,7 +91,7 @@ class PlastexRunner:
         rname = plastex_config['general']['renderer'] = 'makecourse'
         plastex_config['document']['base-url'] = self.get_web_root()
         plastex_config['images']['vector-imager'] = 'none'
-        plastex_config['images']['imager'] = 'dvipng'
+        plastex_config['images']['imager'] = 'pdftoppm'
         document = TeXDocument(config=plastex_config)
         document.userdata['working-dir'] = '.'
 

--- a/makeCourse/plastex/graphicx/__init__.py
+++ b/makeCourse/plastex/graphicx/__init__.py
@@ -1,6 +1,8 @@
 import plasTeX
 from plasTeX import Command
 
+import plasTeX.Packages.graphicx
+
 class includegraphics(plasTeX.Packages.graphicx.includegraphics):
     altText = None
 

--- a/makeCourse/plastex/graphicx/__init__.py
+++ b/makeCourse/plastex/graphicx/__init__.py
@@ -1,0 +1,17 @@
+import plasTeX
+from plasTeX import Command
+
+class includegraphics(plasTeX.Packages.graphicx.includegraphics):
+    altText = None
+
+    def invoke(self, tex):
+        plasTeX.Packages.graphicx.includegraphics.invoke(self,tex)
+        self.ownerDocument.userdata.setPath('packages/makecourse/currentimage', self)
+
+class alt(Command):
+    args = 'text'
+    def invoke(self, tex):
+        Command.invoke(self,tex)
+        doc = self.ownerDocument
+        gfx = doc.userdata.getPath('packages/makecourse/currentimage')
+        gfx.altText = self.attributes['text']

--- a/makeCourse/plastex/tikz/__init__.py
+++ b/makeCourse/plastex/tikz/__init__.py
@@ -5,7 +5,11 @@ from makeCourse.plastex import VerbatimEnvironment
 from plasTeX import Command
 
 class tikzpicture(VerbatimEnvironment):
-    pass
+    altText = None
+    def invoke(self, tex):
+        gfx = VerbatimEnvironment.invoke(self,tex)
+        self.ownerDocument.userdata.setPath('packages/makecourse/currentimage', self)
+        return gfx
 
 class usetikzlibrary(Command):
     args = "library"

--- a/makeCourse/themes/accessible/static/styles.css
+++ b/makeCourse/themes/accessible/static/styles.css
@@ -66,6 +66,13 @@ figure + em, .reveal figure + em {
   margin-top: -10px;
 }
 
+.caption_title {
+	font-weight: bold;
+}
+.caption_ref {
+	font-weight: bold;
+}
+
 
 .centered {
 	text-align: center;

--- a/makeCourse/themes/default/static/styles.css
+++ b/makeCourse/themes/default/static/styles.css
@@ -278,6 +278,12 @@ figure + em, .reveal figure + em {
   margin-top: -10px;
 }
 
+.caption_title {
+	font-weight: bold;
+}
+.caption_ref {
+	font-weight: bold;
+}
 
 .wrapfig {
 	max-width: 35%;


### PR DESCRIPTION
- Switch default imager to pdftoppm so as to handle inserting PDF images with `\includegraphics{}` better.

- Don't force bold captions as part of the HTML templates, instead letting a theme style them however they choose.

- Add an `\alt{}` macro to support adding alt text to images and tikz figures.

The following snippet demonstrates the improvements:
```
\begin{figure}
\includegraphics[width=10cm]{images/hist.pdf}
\caption{A histogram originally provided in .pdf format}
\alt{A plot titled "A histogram". The x axis is labelled "x-axis".
    The y axis is labelled "Frequency". The histogram shows a peak at
    a value of approximately 70.}
\end{figure}
```
