### PR TITLE
Update default template for theme detection in CSS/JS

### DIFF
--- a/makeCourse/themes/default/static/customisation.js
+++ b/makeCourse/themes/default/static/customisation.js
@@ -34,6 +34,10 @@ $("#navbarCustomise #p-space-reset").click(function() {
 	changeParagraphSpacing(150);
 });
 
+function updateThemeBodyTag() {
+	$('body').attr('data-theme', localStorage.getItem('theme') || 'light');
+}
+
 function handleThemeUpdate(theme) {
 	if($('#customiseCSS')[0]){
 		var t =  $('#customiseCSS')[0].getAttribute('href');
@@ -46,6 +50,7 @@ function handleThemeUpdate(theme) {
 	
 	// Save in local storage
 	localStorage.setItem('theme',theme);
+	updateThemeBodyTag();
 }
 
 function changeFontSize(fontScale) {
@@ -108,3 +113,7 @@ function changeParagraphSpacing(paragraphScale) {
 	// Save in local storage
 	localStorage.setItem('css-p-space',paragraphScale);
 }
+
+$(document).ready(() => {
+	updateThemeBodyTag(localStorage.getItem('theme'))
+});

--- a/makeCourse/themes/default/templates/slides_reveal.html
+++ b/makeCourse/themes/default/templates/slides_reveal.html
@@ -48,6 +48,12 @@
 				document.getElementsByTagName( 'head' )[0].appendChild( link );
 			}
 		</script>
+		{% for js in course.config.js %}
+			<script defer src="{{js|static_url}}"></script>
+		{% endfor %}
+		{% for js in item.data.js %}
+			<script defer src="{{js|static_url}}"></script>
+		{% endfor %}
 		{% endblock %}
 
 	</head>
@@ -98,6 +104,7 @@
 					console.log('Problem running MathJax.typeset()');
 				}
 				mp4ImageFallback();
+				updateThemeBodyTag();
 			});
 		</script>
 	</body>


### PR DESCRIPTION
I mentioned some of this in Teams but I figured that I'd actually give it a go to save you the time for something I want!

* Add `body[data-theme]` attribute to enable per-theme CSS via customisation.js (note that is entirely done in JS)
* Add ability to add custom JS to `slides_reveal` template
* Ensure that Reveal slides adds the `body[data-theme]` attribute once the slide deck is ready (reveal runs after the document is ready and effectively wipes out the body tag - at least in my experience)

You're welcome to close this and do it your own way if you prefer, or just commit to this branch (left edit by maintainers on). Just figured I'd pitch in!